### PR TITLE
Scan trade skill once per login

### DIFF
--- a/src/TradeSkillReagents.toc
+++ b/src/TradeSkillReagents.toc
@@ -1,7 +1,7 @@
 ## Interface: 90002
 ## Title: Trade Skill Reagents
 ## Author: Hotel2Oscar
-## Version: 3.0
+## Version: 3.1
 ## Notes: Shows which trade skills use the reagent in the tooltip
 ## X-Category: Tradeskill
 ## X-Embeds: Ace3

--- a/src/TradeSkillReagentsCore.lua
+++ b/src/TradeSkillReagentsCore.lua
@@ -343,12 +343,16 @@ function TradeSkillReagents:ProcessRecipes()
 
     if not tradeSkill or not C_TradeSkillUI.IsTradeSkillReady() then return end
 
-    if scannedTradeSkills[tradeSkill] ~= nil then
+    if scannedTradeSkills[tradeSkill] == nil then
+        scannedTradeSkills[tradeSkill] = 0
+    end
+
+    if scannedTradeSkills[tradeSkill] == 5 then
         self:Debug(tradeSkill .. " already scanned")
         return
     end
 
-    scannedTradeSkills[tradeSkill] = true
+    scannedTradeSkills[tradeSkill] = scannedTradeSkills[tradeSkill] + 1
 
     self:Debug("Scanning " .. tradeSkill)
 

--- a/src/TradeSkillReagentsCore.lua
+++ b/src/TradeSkillReagentsCore.lua
@@ -16,7 +16,7 @@ local defaults = {
                 tradeSkills = {}
             }
         },
-        reagents = {}
+        reagents = {},
     }
 }
 
@@ -74,6 +74,8 @@ local options = {
         }
     }
 }
+
+local scannedTradeSkills = {}
 
 local function dictInsert(dict, key, value)
     if dict[key] then return end
@@ -340,6 +342,13 @@ function TradeSkillReagents:ProcessRecipes()
     local tradeSkill = getTradeSkillName()
 
     if not tradeSkill or not C_TradeSkillUI.IsTradeSkillReady() then return end
+
+    if scannedTradeSkills[tradeSkill] ~= nil then
+        self:Debug(tradeSkill .. " already scanned")
+        return
+    end
+
+    scannedTradeSkills[tradeSkill] = true
 
     self:Debug("Scanning " .. tradeSkill)
 

--- a/src/TradeSkillReagentsCore.lua
+++ b/src/TradeSkillReagentsCore.lua
@@ -315,7 +315,7 @@ function TradeSkillReagents:PruneDB(scannedTradeSkill)
                         dictInsert(prunable, reagent, {})
                         dictInsert(prunable[reagent], tradeSkill, category)
 
-                        self:Debug(reagent .. " (" .. tradeSkill .. " - " ..
+                        self:Print(reagent .. " (" .. tradeSkill .. " - " ..
                                     category .. ") will be pruned")
                     end
                 end


### PR DESCRIPTION
Closes #23 

Noticed that trade skill was being scanned each time something was crafted (possibly due to skill up).

Now trade skill will only be scanned ~~once~~ 5 times per character login or '/reload'